### PR TITLE
Auth grant type jwt bearer e2e tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -83,14 +83,11 @@ docker:
 .PHONY: e2e
 e2e: node_modules test-resetdb
 		source ./scripts/test-env.sh
-		./test/e2e/circle-ci.bash memory
-		./test/e2e/circle-ci.bash memory-jwt
-		./test/e2e/circle-ci.bash postgres
-		./test/e2e/circle-ci.bash postgres-jwt
-		./test/e2e/circle-ci.bash mysql
-		./test/e2e/circle-ci.bash mysql-jwt
-		./test/e2e/circle-ci.bash cockroach
-		./test/e2e/circle-ci.bash cockroach-jwt
+		for db in memory postgres mysql cockroach; do \
+			./test/e2e/circle-ci.bash "$${db}"; \
+			./test/e2e/circle-ci.bash "$${db}" --jwt; \
+			./test/e2e/circle-ci.bash "$${db}" --grant_jwt_client_auth_optional --grant_jwt_jti_optional --grant_jwt_iat_optional; \
+		done
 
 # Runs tests in short mode, without database adapters
 .PHONY: quicktest

--- a/cmd/janitor.go
+++ b/cmd/janitor.go
@@ -10,7 +10,7 @@ import (
 func NewJanitorCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "janitor [<database-url>]",
-		Short: "Clean the database of old tokens and login/consent requests",
+		Short: "Clean the database of old tokens, login/consent requests and jwt grant issuers",
 		Long: `This command will cleanup any expired oauth2 tokens as well as login/consent requests.
 
 ### Warning ###
@@ -45,9 +45,13 @@ Janitor can be used in several ways.
 
 		janitor --requests <database-url>
 
-   or both
+    or
 
-		janitor --tokens --requests <database-url>
+		janitor --grants <database-url>
+
+   or any combination of them
+
+		janitor --tokens --requests --grants <database-url>
 `,
 		RunE: cli.NewHandler().Janitor.RunE,
 		Args: cli.NewHandler().Janitor.Args,
@@ -56,8 +60,9 @@ Janitor can be used in several ways.
 	cmd.Flags().Duration(cli.AccessLifespan, 0, "Set the access token lifespan e.g. 1s, 1m, 1h.")
 	cmd.Flags().Duration(cli.RefreshLifespan, 0, "Set the refresh token lifespan e.g. 1s, 1m, 1h.")
 	cmd.Flags().Duration(cli.ConsentRequestLifespan, 0, "Set the login/consent request lifespan e.g. 1s, 1m, 1h")
-	cmd.Flags().Bool(cli.OnlyRequests, false, "This will only run the cleanup on requests and will skip token cleanup.")
-	cmd.Flags().Bool(cli.OnlyTokens, false, "This will only run the cleanup on tokens and will skip requests cleanup.")
+	cmd.Flags().Bool(cli.OnlyRequests, false, "This will only run the cleanup on requests and will skip token and trust relationships cleanup.")
+	cmd.Flags().Bool(cli.OnlyTokens, false, "This will only run the cleanup on tokens and will skip requests and trust relationships cleanup.")
+	cmd.Flags().Bool(cli.OnlyGrants, false, "This will only run the cleanup on trust relationships and will skip requests and token cleanup.")
 	cmd.Flags().BoolP(cli.ReadFromEnv, "e", false, "If set, reads the database connection string from the environment variable DSN or config file key dsn.")
 	configx.RegisterFlags(cmd.PersistentFlags())
 	return cmd

--- a/cypress.json
+++ b/cypress.json
@@ -6,7 +6,10 @@
     "client_url": "http://127.0.0.1:5003",
     "public_port": "5000",
     "client_port": "5003",
-    "jwt_enabled": false
+    "jwt_enabled": false,
+    "grant_jwt_client_auth_optional": false,
+    "grant_jwt_jti_optional": false,
+    "grant_jwt_iat_optional": false
   },
   "chromeWebSecurity": false,
   "retries": {

--- a/cypress/helpers/index.js
+++ b/cypress/helpers/index.js
@@ -56,3 +56,146 @@ const getClient = (id) =>
   cy
     .request(Cypress.env('admin_url') + '/clients/' + id)
     .then(({ body }) => body)
+
+export const createGrant = (grant) =>
+  cy
+    .request('POST', Cypress.env('admin_url') + '/trust/grants/jwt-bearer/issuers', JSON.stringify(grant))
+    .then((response) => {
+      const grantID = response.body.id
+      getGrant(grantID).then((actual) => {
+        if (actual.id !== grantID) {
+          return Promise.reject(
+            new Error(
+              `Expected id's to match: ${actual.id} !== ${grantID}`
+            )
+          )
+        }
+        return Promise.resolve(response)
+      })
+    })
+
+export const getGrant = (grantID) =>
+  cy
+    .request('GET', Cypress.env('admin_url') + '/trust/grants/jwt-bearer/issuers/' + grantID)
+    .then(({ body }) => body)
+
+export const deleteGrants = () =>
+  cy.request(Cypress.env('admin_url') + '/trust/grants/jwt-bearer/issuers').then(({ body = [] }) => {
+    ;(body || []).forEach(({ id }) => deleteGrant(id))
+  })
+
+const deleteGrant = (id) =>
+  cy.request('DELETE', Cypress.env('admin_url') + '/trust/grants/jwt-bearer/issuers/' + id)
+
+export const publicJwk = {
+    kid: 'token-service-key',
+    kty: 'RSA',
+    alg: 'RS256',
+    n: 'xbOXL8LDbB8hz4fe6__qpESz5GqX0IjH9lRIywG1xj7_w9UXnds5oZpXp0L4TM7B9j0na6_wIwcnfTlQr1cW3LHJXjzPS19zK5rrvB5eabNhtv4yIyH2DSfkI5J3y0bmfY74_J_rDFtQ1PdpfMzdF5cceYvw05B3Q6naPwPN_86GjOkxBWeBZ1-jL5-7cpbbAfeICjEEBsKDX0j-2ZyKpQ2r4jrxwxDF-J3Xsf6ieRKHggQfG-_xMucz40j7t_s-ttE8LoOm9Mmg0gl6vsfhL9rBvUiW-FLCgCqAKSB9a4JHp4_cgsUUR4TsPrJXTGXDFPoqd63S4ZLkCqOeFLOMUx7zVM_gVyyDIbfXWG2HRt6IbEiU8-A-irw0PtPKKiZ0mue2DT3gbvRJlKpL4RG8Obhlaxzf1eQ9jLx15_DoJt9M8zrK9m99YNRMBeJWwJ-RaUv0odpMkIMawH-ly0IO4Kc6fV2g0PK0f4lBnoHze802Y5SQfN19D3GaL93xlHDTHIsX_q0ICyQzupHjQeFHSa9ku0mA36p40lE3Ejpxjbx1BNAvwozGIE7OuovtUgnaodzpRp5HMrCS5YSGE0LtpTgyEibrG3pA12tSvQW3WDeB8qx4dPBBo917ujdgO23p9ZYm96ohZMUOSR_ItX7n3Q4N6W490YrNgj6c-r9kfWk',
+    e: 'AQAB'
+}
+export const privatePem = `-----BEGIN RSA PRIVATE KEY-----
+MIIJKQIBAAKCAgEAxbOXL8LDbB8hz4fe6//qpESz5GqX0IjH9lRIywG1xj7/w9UX
+nds5oZpXp0L4TM7B9j0na6/wIwcnfTlQr1cW3LHJXjzPS19zK5rrvB5eabNhtv4y
+IyH2DSfkI5J3y0bmfY74/J/rDFtQ1PdpfMzdF5cceYvw05B3Q6naPwPN/86GjOkx
+BWeBZ1+jL5+7cpbbAfeICjEEBsKDX0j+2ZyKpQ2r4jrxwxDF+J3Xsf6ieRKHggQf
+G+/xMucz40j7t/s+ttE8LoOm9Mmg0gl6vsfhL9rBvUiW+FLCgCqAKSB9a4JHp4/c
+gsUUR4TsPrJXTGXDFPoqd63S4ZLkCqOeFLOMUx7zVM/gVyyDIbfXWG2HRt6IbEiU
+8+A+irw0PtPKKiZ0mue2DT3gbvRJlKpL4RG8Obhlaxzf1eQ9jLx15/DoJt9M8zrK
+9m99YNRMBeJWwJ+RaUv0odpMkIMawH+ly0IO4Kc6fV2g0PK0f4lBnoHze802Y5SQ
+fN19D3GaL93xlHDTHIsX/q0ICyQzupHjQeFHSa9ku0mA36p40lE3Ejpxjbx1BNAv
+wozGIE7OuovtUgnaodzpRp5HMrCS5YSGE0LtpTgyEibrG3pA12tSvQW3WDeB8qx4
+dPBBo917ujdgO23p9ZYm96ohZMUOSR/ItX7n3Q4N6W490YrNgj6c+r9kfWkCAwEA
+AQKCAgAJvNrJg3JUtQPZUPvt6+EGzkt+CLIJl3Mh8uzS8vadGSVH5AsRv2aLSyre
+FjJctiJfmouChlvxnbyYMmaC/Gsn26nrdltPfxgRIcRSs7w6wJcjiEm36UhRRZG7
+Hs+/t3JK5OvmpYnSRf0pQDZ16zFIpCzG39mw0gDN2GPjjrBq1SVTc3jypzJ8gP1s
+rxVwg3WuFx8gQWHNY29NFi9XUJqTnqTEs9qMnRrjMAMbxUsDY6JBCSrvGVZsB29K
+1qFvYnSoVI3+TIXAsN22+riNBRNWZBP+2sB04r6pyW4emHcVAIm++xsFZeelzipE
+vEwIe0qskdXdpzYn3jBVRdHXezCCIU7xu8CKB2JqhOgOR10L4RARfgN6Xw0thQhH
+j9cMim2khgpzIXnhOtA3vFKMlrskY+4CXZzWaL1WkpDZKoionmRaID6uU0+rdk0C
+Ue2vzoSSUw42UQyV3Lm/AcyiDBOH9JAmma5yC2VuPNMSe2yIln8/cwrgFbjP9ksl
+mG8NZj/plzpsAtPQCiPE4X2rPdABD/mOEdovqh7cASaT5kSCEneZ+ln5mkMVPcB8
+688vI+5JmRWXdGYKSqTXXIjjoy4FjaQtaFgyf2hvnfUQQ9mm/I8LEkHUCjrHoe7Y
+5o7j+Ft8TO514T1pm3vgP/a8czDvOLUvBysEb3Kw4Zyl7ZODMQKCAQEA+g16bOVc
+oZ09nesTuK4aNzljxQcljKqAXoUvT9hvN8epAQOmYOKUToP+4EBi6ro5mAPTq4DU
+pkS7ATSIEu2/Oe9MvPMdWQijTddZSP6yCgzC+67V+Y0Rtvf/vtxE8TFQCi7jUlOs
+/+lAMwmi31K0PUJSU/Fh9qzS/7zlOG7cc1FXcf5DJz4LQWP842rdWf+y/tIWQYhQ
+tnrDoBLyCwyppW52kTyJFjXPiHYk2VHrImVa0bPo7rcagrGbwOmQkQvJDT496Y2h
+qbPI1H9G3XkSVlpBhaVgPYb/1zFRNrbiQ8/O6AMn5FSF6e3Y3xUvgnf5qnD/aQ7v
+XtU3S9zbSV4PRwKCAQEAymdbSHh1UH5TLvkFn/cNtyySBixjOKZk6rS5OI4XcdVQ
+xr0YMo/hQRjQHZxkWw3Oto4jXmad02eVyJ/ttyHO0bNChMISqh/STkUKlOb8zaMJ
+US6Hu7hJFSDe7OjxKgn5Sj3KHe9DhlhIW4Hzgbb7+zAvhjn60IlcjisFNSlu7Og+
++vaUuOBLjDl0TYPBMvUzFT4Z0RIiHu9L6lqa4ka6TC/CbtrNRVbv9IYNlbs1K4xQ
+SwjpbIKOxFAoWK/Y+XGBJrD4XKSgOufcRyYUsmanF46Ag2H3gkmPqmqK1Ykbrr69
+Au/hj5xtN/SuwjWNclWvO+2Ck8WYsorTA3ErqAhFzwKCAQAjYmjipApZrGCdyjg+
+OBTpn6topDxCDZagyYQKbnw+jnhx9kxDBY0rFy6oGTRmNvgTdOctK8vrw2obH43p
+787RqfVX/6c1hC1nxIOT+sbC+U9WQkVxTO8mzy1Xmt/+qZXD+yKb8c9XX3CASGrN
+42wyBwKTcmMEfyxUmCxvsfBsOSSAsxRZp0P8euO8YtDz/WUc/im8GEgjqneoXUX3
+HlGbYWhR4RkdFXxKuT05q4f0lBcn+aeKsEqGGBAMWoDkpaBLyXUFac9orlJLD7+9
+c3aO1bLT8LUPv9zQXOA7N+II6o1C879fZj6U/d1kpCDW+5dO8TKTcVOaPd3XVGeL
+mE3dAoIBAQCE3mCwLFNm6eaVeWfV4Qqh6qJZZx4jfCfXY5gLpkuBsLT8IfoWhxkp
+8K3+IkJG+8NtV9WkDN0igGd1cndMtubcBj9ugzBZedZHB0+w/AmMvLBLGK6F7q4b
+Lp7pCun13OJHeFSMXhsHwECPwbkmuAammLU5+inKZ8HYmikrAu4Mm1Fs0h5DVwqB
+HN5aXFmhqBFGqqOr+alogVJmn9/5FtEJXnjW6M/D6xROgwm7908qLUwwVcNWNkae
+XLh/r8BRz88mpRoFRxTgVoDmO/tuObEK58M5fEBMyRmEl7hYAU+o4RGXMf3ylo+k
+If3vA9S8776/KmWDuD1LR5LKOaqc/gFFAoIBAQDjlsI3A7yRx5CCOSS1zdrZXDve
+dmpzjun13OqPe1N2PGbgvrrMY9oEbZ4jf1FMNUYFQafHWr8+iQRbm+WS2fZSq6ie
+z8+vwhIQzyYAKDOHcfk/ImVCnCZOpWUv78T3ftBOm0flK9FgmtEVU9lZOGwJeeSl
+XfXvA23Yq6h4NYvugw6YyamOjy8EnYwO707ibJVajeNFukrZO3Ywcaz1/jn/iaDv
+KArlIAJ3R/phf9+e35pBAtjM6NYqzqVp93MUwMTXnK8TAPhtT8rEsP6Q5T703Lof
+kphJ2V/clAXtRXwP+588e7JveeZlOS+3vUm3JWv+zHtWGY3SXefcialXfNN/
+-----END RSA PRIVATE KEY-----
+`
+
+export const invalidPrivatePem = `-----BEGIN RSA PRIVATE KEY-----
+MIIJJgIBAAKCAgBh2paLu/KqIYKapXLXD2kHt4TDGWCProE55heq9hdC0T8+zI0i
+dAuwkIytczMEliM9S/HbOci7yUZNGnBEBTOYaA02ihkxuYQx+4wxTCBump6NW9um
+NU3ZNj7jCglOGDCAT3He+/PeXu07N/U5+J2bmHRT4901p+o0MihJUvxZwHCFxRjP
+q8o6HPFWsKrL+EcrA2yCuari4AMRwO8Kk6n6OqNpTtbEPgTeYryfGTTLnatnoX8C
+tAvoEZCy0b7p9zXuBcR0dAX6AKfshz3xUe10Xo6Hm/02ZU6ckaWh9OEkNsIWs/L4
+xXfKt9IU6ZkNvN2grDftA9z6fW8FvoFhVhdPOCiZO8DgUEMZIuAdndkBUdAPpDfd
+tr0hugakGq87OzpniksKgH3meTEVGKt5OWZHQ/GcLSakOcd08e5SkuhltRafbyFl
+vB9gzi3WVz18ZeymXu4QP07KYDCOX1fdLW7HrKBvf4aYLDKQeMIHoZvIDWuDThVh
+E75weAEcezPXAsEE1zcvDajCZmQOdgv0Trc9wxHAeRZV1hoxhheAflxG8YkMTNS3
+PcBFrHz+wjzuYUDh0yTUzFiUeUQxb2zMz0iqYkfl7Ov+ApgyysFHbCfrb88HvlFj
+nYpyE0JVxA83O7QuQ/ZCtmTmalHk1y2jti0HEOGM6wJvWwZLL5pjGK1aEwIDAQAB
+AoICAAaFOUjgYkAh8YD6i1d3SGliOi+B7mREnYnNIkCbG1uxc8Rsfu8PyoOebjFU
+ns6sbna0K86O4ChbNhsHKvntWs3KCS9cLmeY1A08lM/oIbUdCnmi6FT/8ksKCVC5
+p3sTs4+pO44/PbXQn4A1r1qIjYADvaSlZ2Ue5kVKHlMce4JDh3vycT/NU7FholdD
+eG4VAjEEjmN7mb56bNnvAD61LjtlUuQ+g6MZ+tsSuzziwhjbTcOfCEaW1sBFA15X
+CaCvf2F38upLnOZWytnA/UiqS+dYMakppMrOH1nhfqb3GVV/bJl0rjkTd3MDorUQ
+B8nZju8Y6rUZb80lNJOuaRKiWPUyOlIqnITBPXCAd6joqpyuKkoD5D/rZ46W+0n3
+yVa+p9cfapvXuU5ChwxBMBsa8sMQ5TSb365H6GVZkFSVSfEg4NjicTxYIC3QuEdq
+zTRWTTu4lYDWaTK61o/0LKFqg+DUehSxnx9S9zUzxB0GMZzOEXTmXaJWN+1kvmgv
+2NVI6WfPjaNgeG+Nr9qw5simyxbmN0vHV8FjrmgGZMNf7ogibMtnECW4MxYN+6Ie
+rY5AeMry+5iOPbuSUc75JmbAYHvw0wt9o4D/gcwLKIUNoGpiyihXy9GLllYR2bHM
+VaZk+bwqqMcGX4pFio+fQJNcmw6msDiK20TT1cnhrYIrbpSJAoIBAQCtyKRI49Cv
+qQI7AEYwMxym7exTSaFeN8T1m+CCetvx8ss5Kce/+RgrWauVh7WNOj+wR+3DfRL+
+1NhMgTiuWt2EjrzHmX/0Fugm2Z28JxofkS7MSuSqPwA9L4pUfHOqsmXptMxSTiG2
+ypgkWfUyQh+c8lAZWpds3kUXptnzORk2vsNkk6sebuJewF3TxURGqcHdl3t/IyGQ
+sc396ztoPWOSIx/mc+2D5XtcOOrHR8SEwZsr9dPYQTAqV+v/6/MJ68ZU3nSp1E15
+Wd5YfRNIc20Hg9UTM1XXGCipa75/OguCd/OqVYVxBprLC8pv3kuhxn43rbbueRiu
+LZIbUhQmTfHHAoIBAQCQJeYBEYF8Ar5zj1UI9uNGDmL37XwWbTXtopMcM8E+OX7u
+uF8p+FmKNBsBGJvsi9D2MIouFgIKx6CTgbovrMC2Emv80Wvi2d7lOk1pZgrXLXKo
+yHzHLlK4/8wEBdHKLZ5L7JC6c1JmuDaHVIE2KC53fiBIGh+ogGeZlC6VwRvXOUJF
+W0w82hYSV97IhzKMM18YaIHnvvz3KPpCbQBmYQJizWaETSmcQx8igDe4nf9b8An+
+NF2GvtNklzG9vbSeMJztK8EQgKSxpUun3z69yx71qCnvwPFg68VFCau5358N0YeM
+B+6BEgy3b4n4nvmDOquvPKyYXQoNAiBXyqIEU1VVAoIBAHUWhnoF5Ik2GiaenKvF
+BD0EeQH0ziCo+q9xAudm1+JAb+Rn3gneTwaGODFbaltpL5gaHnxkPPQtfD6vofz3
+g+DYOyFQrwFKncfvP3OR9Ovn6dwDaeW65PJUoaMi5tvPrxKzmiaqNdTu02tKoQXn
+v10Ddixe+T+E0pCI/rf9dJuKFCQjyluK4kJs4crZUpM5tUET20Vh6i+PXPcEEta8
+5eWEfO3Mle8UIvWT87upAyNfPqlzy/Qcl9MvwfaAhxPcI5jy+S+jtz9X6ZM9Ukyy
+WHeDv4BcSi3OPTdJPOSDu1WAdFADpxDsHkdH/nE5GUQ6dLgW9vXd6V8RnSuDNchJ
+I+kCggEAZaCimWw7KzBQD+8k164grBqmgf+INdOHauPs7bw7aOBmcm3Agjma/0of
+I9Wy0MH+cCPmt/lCNVFrD7QtjUExmOxCADux4X0Tne9N9po/2FcteHvpJRCut8l4
+j/l+YBlrekHuA9YcaVlE8IKOmp0XrZ1Zqxvn6AenguqrMV+1fjbbV0S36ksjtokH
+A7/1zkzFpdLAi5/mf2b/keeBmayZXwlLVsmEJaxY/h0BrAKQr8P7d6J5se9F4KyM
+ICboeYLykHABrN3Vv303asKFXJAhYrbN4j/YrilrqnHYBbL4U2i/NOW+rHcKSiW0
+U3nZlkC+HE0drkoiNOuj2+F7+qq6BQKCAQAZK0uKuSAUJXSMSJWogpNLjHbg37bM
+RHpdzPxpJhrhsU4XN1W5g153qfZBdioXGGeEYrfnKM+QG5VkbZ80C7TSe/CMeOyn
+J1kxh2BZV3VP0xzdaQOcL/rHn7uq75KD5t8JwIQM8N1sos1D1/k8vz9RjElvZ3kx
+gkrdwl3XTM//5Aq8iUZtt5OA7Jel/Iw9e4QBf6F2pYl73BStBbUHtWPC9we8qj3p
+JgGFwiBBmFjZqu1oo0Q4mteDIIEHvbebD6G0nibilORZGOFnCVE7f0HYEzHDAzVe
+OgyQybTowIznIMk7WuoLS2Kq1GghMm1l1gkmXj5hmmSIg8GBwRWa+5x6
+-----END RSA PRIVATE KEY-----
+`

--- a/cypress/integration/oauth2/grant_jwtbearer.js
+++ b/cypress/integration/oauth2/grant_jwtbearer.js
@@ -1,0 +1,688 @@
+import { createClient, createGrant, deleteGrants, deleteClients, prng, privatePem, publicJwk, invalidPrivatePem } from '../../helpers'
+
+const dayjs = require('dayjs')
+const isBetween = require('dayjs/plugin/isBetween')
+const utc = require('dayjs/plugin/utc')
+dayjs.extend(utc)
+dayjs.extend(isBetween)
+
+const jwt = require('jsonwebtoken')
+
+describe('The OAuth 2.0 JWT Bearer (RFC 7523) Grant', function () {
+    beforeEach(() => {
+        deleteGrants()
+        deleteClients()
+    })
+
+    const tokenUrl = `${Cypress.env('public_url')}/oauth2/token`
+
+    const canSkipClientAuth = () => Cypress.env('grant_jwt_client_auth_optional') === 'true' || Boolean(Cypress.env('grant_jwt_client_auth_optional'))
+    const jtiOptional = () => Cypress.env('grant_jwt_jti_optional') === 'true' || Boolean(Cypress.env('grant_jwt_jti_optional'))
+    const iatOptional = () => Cypress.env('grant_jwt_iat_optional') === 'true' || Boolean(Cypress.env('grant_jwt_iat_optional'))
+
+    const nc = () => ({
+        client_id: prng(),
+        client_secret: prng(),
+        scope: 'foo openid offline_access',
+        grant_types: ['urn:ietf:params:oauth:grant-type:jwt-bearer'],
+        token_endpoint_auth_method: 'client_secret_post',
+        response_types: ['token'],
+    })
+
+    const gr = (subject) => ({
+        issuer: prng(),
+        subject: subject,
+        scope: ['foo', 'openid', 'offline_access'],
+        jwk: publicJwk,
+        expires_at: dayjs().utc().add(1, 'year').set('millisecond', 0).toISOString(),
+    })
+
+    const jwtAssertion = (grant, override) => {
+        const assert = {
+            "jti": prng(),
+            "iss": grant.issuer,
+            "sub": grant.subject,
+            "aud": tokenUrl,
+            "exp": dayjs().utc().add(2, 'minute').set('millisecond', 0).unix(),
+            "iat": dayjs().utc().subtract(2, 'minute').set('millisecond', 0).unix(),
+        }
+        return {...assert, ...override}
+    }
+
+    it('should return an Access Token when given client credentials and a signed JWT assertion', function () {
+        const client = nc()
+        createClient(client)
+
+        const grant = gr(prng())
+        createGrant(grant)
+
+        const assertion = jwt.sign(jwtAssertion(grant), privatePem, { algorithm: "RS256" })
+
+        cy.request({
+            method: 'POST', 
+            url: tokenUrl,
+            form: true,
+            body: {
+                grant_type: 'urn:ietf:params:oauth:grant-type:jwt-bearer',
+                assertion: assertion,
+                scope: client.scope,
+                client_secret: client.client_secret,
+                client_id: client.client_id
+            },
+        })
+        .its('body')
+        .then((body) => {
+            const { access_token, expires_in, scope, token_type } = body
+
+            expect(access_token).to.not.be.empty
+            expect(expires_in).to.not.be.undefined
+            expect(scope).to.not.be.empty
+            expect(token_type).to.not.be.empty
+        })
+    })
+
+    
+
+    it('[client auth required] should return an Error (400) when not given client credentials', function () {
+        if (canSkipClientAuth()) {
+            this.skip()
+        }
+
+        const client = nc()
+        createClient(client)
+
+        const grant = gr(prng())
+        createGrant(grant)
+
+        const assertion = jwt.sign(jwtAssertion(grant), privatePem, { algorithm: "RS256" })
+
+        cy.request({
+            method: 'POST', 
+            url: tokenUrl,
+            form: true,
+            body: {
+                grant_type: 'urn:ietf:params:oauth:grant-type:jwt-bearer',
+                assertion: assertion,
+                scope: client.scope,
+            },
+            failOnStatusCode: false,
+        })
+        .its('status')
+        .then((status) => {
+            expect(status).to.be.equal(400)
+        })
+    })
+
+    it('[jti required] should return an Error (400) when given client credentials and a JWT assertion without a jti', function () {
+        if (jtiOptional()) {
+            this.skip()
+        }
+
+        const client = nc()
+        createClient(client)
+
+        const grant = gr(prng())
+        createGrant(grant)
+
+        var ja = jwtAssertion(grant)
+        delete ja["jti"]
+        const assertion = jwt.sign(ja, privatePem, { algorithm: "RS256" })
+
+        // first token request should work fine
+        cy.request({
+            method: 'POST', 
+            url: tokenUrl,
+            form: true,
+            body: {
+                grant_type: 'urn:ietf:params:oauth:grant-type:jwt-bearer',
+                assertion: assertion,
+                scope: client.scope,
+                client_secret: client.client_secret,
+                client_id: client.client_id
+            },
+            failOnStatusCode: false,
+        })
+        .its('status')
+        .then((status) => {
+            expect(status).to.be.equal(400)
+        })
+    })
+
+    it('should return an Error (400) when given client credentials and a JWT assertion with a duplicated jti', function () {
+        const client = nc()
+        createClient(client)
+
+        const grant = gr(prng())
+        createGrant(grant)
+
+        const jwt1 = jwtAssertion(grant)
+        const assertion1 = jwt.sign(jwt1, privatePem, { algorithm: "RS256" })
+
+        // first token request should work fine
+        cy.request({
+            method: 'POST', 
+            url: tokenUrl,
+            form: true,
+            body: {
+                grant_type: 'urn:ietf:params:oauth:grant-type:jwt-bearer',
+                assertion: assertion1,
+                scope: client.scope,
+                client_secret: client.client_secret,
+                client_id: client.client_id
+            },
+        })
+        .its('body')
+        .then((body) => {
+            const { access_token, expires_in, scope, token_type } = body
+
+            expect(access_token).to.not.be.empty
+            expect(expires_in).to.not.be.undefined
+            expect(scope).to.not.be.empty
+            expect(token_type).to.not.be.empty
+        })
+
+        const assertion2 = jwt.sign(jwtAssertion(grant, {jti: jwt1["jti"]}), privatePem, { algorithm: "RS256" })
+
+        // the second should fail
+        cy.request({
+            method: 'POST', 
+            url: tokenUrl,
+            form: true,
+            body: {
+                grant_type: 'urn:ietf:params:oauth:grant-type:jwt-bearer',
+                assertion: assertion2,
+                scope: client.scope,
+                client_secret: client.client_secret,
+                client_id: client.client_id
+            },
+            failOnStatusCode: false,
+        })
+        .its('status')
+        .then((status) => {
+            expect(status).to.be.equal(400)
+        })
+    })
+
+    it('[iat required] should return an Error (400) when given client credentials and a JWT assertion without an iat', function () {
+        if (iatOptional()) {
+            this.skip()
+        }
+
+        const client = nc()
+        createClient(client)
+
+        const grant = gr(prng())
+        createGrant(grant)
+
+        var ja = jwtAssertion(grant)
+        delete ja["iat"]
+        const assertion = jwt.sign(ja, privatePem, { algorithm: "RS256", noTimestamp: true })
+
+        // first token request should work fine
+        cy.request({
+            method: 'POST', 
+            url: tokenUrl,
+            form: true,
+            body: {
+                grant_type: 'urn:ietf:params:oauth:grant-type:jwt-bearer',
+                assertion: assertion,
+                scope: client.scope,
+                client_secret: client.client_secret,
+                client_id: client.client_id
+            },
+            failOnStatusCode: false,
+        })
+        .its('status')
+        .then((status) => {
+            expect(status).to.be.equal(400)
+        })
+    })
+
+    it('should return an Error (400) when given client credentials and a JWT assertion with an invalid signature', function () {
+        const client = nc()
+        createClient(client)
+
+        const grant = gr(prng())
+        createGrant(grant)
+
+        const assertion = jwt.sign(jwtAssertion(grant), invalidPrivatePem, { algorithm: "RS256" })
+
+        cy.request({
+            method: 'POST', 
+            url: tokenUrl,
+            form: true,
+            body: {
+                grant_type: 'urn:ietf:params:oauth:grant-type:jwt-bearer',
+                assertion: assertion,
+                scope: client.scope,
+                client_secret: client.client_secret,
+                client_id: client.client_id
+            },
+            failOnStatusCode: false,
+        })
+        .its('status')
+        .then((status) => {
+            expect(status).to.be.equal(400)
+        })
+    })
+
+    it('should return an Error (400) when given client credentials and a JWT assertion with an invalid subject', function () {
+        const client = nc()
+        createClient(client)
+
+        const grant = gr(prng())
+        createGrant(grant)
+
+        const assertion = jwt.sign(jwtAssertion(grant, {"sub": "invalid_subject"}), privatePem, { algorithm: "RS256" })
+
+        cy.request({
+            method: 'POST', 
+            url: tokenUrl,
+            form: true,
+            body: {
+                grant_type: 'urn:ietf:params:oauth:grant-type:jwt-bearer',
+                assertion: assertion,
+                scope: client.scope,
+                client_secret: client.client_secret,
+                client_id: client.client_id
+            },
+            failOnStatusCode: false,
+        })
+        .its('status')
+        .then((status) => {
+            expect(status).to.be.equal(400)
+        })
+    })
+
+    it('should return an Error (400) when given client credentials and a JWT assertion with an invalid issuer', function () {
+        const client = nc()
+        createClient(client)
+
+        const grant = gr(prng())
+        createGrant(grant)
+
+        const assertion = jwt.sign(jwtAssertion(grant, {"iss": "invalid_issuer"}), privatePem, { algorithm: "RS256" })
+
+        cy.request({
+            method: 'POST', 
+            url: tokenUrl,
+            form: true,
+            body: {
+                grant_type: 'urn:ietf:params:oauth:grant-type:jwt-bearer',
+                assertion: assertion,
+                scope: client.scope,
+                client_secret: client.client_secret,
+                client_id: client.client_id
+            },
+            failOnStatusCode: false,
+        })
+        .its('status')
+        .then((status) => {
+            expect(status).to.be.equal(400)
+        })
+    })
+
+    it('should return an Error (400) when given client credentials and a JWT assertion with an invalid audience', function () {
+        const client = nc()
+        createClient(client)
+
+        const grant = gr(prng())
+        createGrant(grant)
+
+        const assertion = jwt.sign(jwtAssertion(grant, {"aud": "invalid_audience"}), privatePem, { algorithm: "RS256" })
+
+        cy.request({
+            method: 'POST', 
+            url: tokenUrl,
+            form: true,
+            body: {
+                grant_type: 'urn:ietf:params:oauth:grant-type:jwt-bearer',
+                assertion: assertion,
+                scope: client.scope,
+                client_secret: client.client_secret,
+                client_id: client.client_id
+            },
+            failOnStatusCode: false,
+        })
+        .its('status')
+        .then((status) => {
+            expect(status).to.be.equal(400)
+        })
+    })
+
+    it('should return an Error (400) when given client credentials and a JWT assertion with an expired date', function () {
+        const client = nc()
+        createClient(client)
+
+        const grant = gr(prng())
+        createGrant(grant)
+
+        const assertion = jwt.sign(jwtAssertion(grant, {"exp": dayjs().utc().subtract(1, 'minute').set('millisecond', 0).unix()}), privatePem, { algorithm: "RS256" })
+
+        cy.request({
+            method: 'POST', 
+            url: tokenUrl,
+            form: true,
+            body: {
+                grant_type: 'urn:ietf:params:oauth:grant-type:jwt-bearer',
+                assertion: assertion,
+                scope: client.scope,
+                client_secret: client.client_secret,
+                client_id: client.client_id
+            },
+            failOnStatusCode: false,
+        })
+        .its('status')
+        .then((status) => {
+            expect(status).to.be.equal(400)
+        })
+    })
+
+    it('should return an Error (400) when given client credentials and a JWT assertion with a nbf that is still not valid', function () {
+        const client = nc()
+        createClient(client)
+
+        const grant = gr(prng())
+        createGrant(grant)
+
+        const assertion = jwt.sign(jwtAssertion(grant, {"nbf": dayjs().utc().add(1, 'minute').set('millisecond', 0).unix()}), privatePem, { algorithm: "RS256" })
+
+        cy.request({
+            method: 'POST', 
+            url: tokenUrl,
+            form: true,
+            body: {
+                grant_type: 'urn:ietf:params:oauth:grant-type:jwt-bearer',
+                assertion: assertion,
+                scope: client.scope,
+                client_secret: client.client_secret,
+                client_id: client.client_id
+            },
+            failOnStatusCode: false,
+        })
+        .its('status')
+        .then((status) => {
+            expect(status).to.be.equal(400)
+        })
+    })
+
+    it('should return an Access Token when given client credentials and a JWT assertion with a nbf that is valid', function () {
+        const client = nc()
+        createClient(client)
+
+        const grant = gr(prng())
+        createGrant(grant)
+
+        const assertion = jwt.sign(jwtAssertion(grant, {"nbf": dayjs().utc().subtract(1, 'minute').set('millisecond', 0).unix()}), privatePem, { algorithm: "RS256" })
+
+        cy.request({
+            method: 'POST', 
+            url: tokenUrl,
+            form: true,
+            body: {
+                grant_type: 'urn:ietf:params:oauth:grant-type:jwt-bearer',
+                assertion: assertion,
+                scope: client.scope,
+                client_secret: client.client_secret,
+                client_id: client.client_id
+            },
+        })
+        .its('body')
+        .then((body) => {
+            const { access_token, expires_in, scope, token_type } = body
+
+            expect(access_token).to.not.be.empty
+            expect(expires_in).to.not.be.undefined
+            expect(scope).to.not.be.empty
+            expect(token_type).to.not.be.empty
+        })
+    })
+
+    it('[client auth optional] should return an Access Token when given a signed JWT assertion', function () {
+        if (!canSkipClientAuth()) {
+            this.skip()
+        }
+        
+        const client = nc()
+        createClient(client)
+        
+        const grant = gr(prng())
+        createGrant(grant)
+
+        const assertion = jwt.sign(jwtAssertion(grant), privatePem, { algorithm: "RS256" })
+
+        cy.request({
+            method: 'POST', 
+            url: tokenUrl,
+            form: true,
+            body: {
+                grant_type: 'urn:ietf:params:oauth:grant-type:jwt-bearer',
+                assertion: assertion,
+                scope: grant.scope,
+            },
+        })
+        .its('body')
+        .then((body) => {
+            const { access_token, expires_in, scope, token_type } = body
+
+            expect(access_token).to.not.be.empty
+            expect(expires_in).to.not.be.undefined
+            expect(scope).to.not.be.empty
+            expect(token_type).to.not.be.empty
+        })
+    })
+
+    it('[client auth optional] should return an Error (400) when given a JWT assertion with an invalid signature', function () {
+        if (!canSkipClientAuth()) {
+            this.skip()
+        }
+
+        const client = nc()
+        createClient(client)
+
+        const grant = gr(prng())
+        createGrant(grant)
+
+        const assertion = jwt.sign(jwtAssertion(grant), invalidPrivatePem, { algorithm: "RS256" })
+
+        cy.request({
+            method: 'POST', 
+            url: tokenUrl,
+            form: true,
+            body: {
+                grant_type: 'urn:ietf:params:oauth:grant-type:jwt-bearer',
+                assertion: assertion,
+                scope: client.scope,
+            },
+            failOnStatusCode: false,
+        })
+        .its('status')
+        .then((status) => {
+            expect(status).to.be.equal(400)
+        })
+    })
+
+    it('[client auth optional] should return an Error (400) when given a JWT assertion with an invalid subject', function () {
+        if (!canSkipClientAuth()) {
+            this.skip()
+        }
+        
+        const client = nc()
+        createClient(client)
+
+        const grant = gr(prng())
+        createGrant(grant)
+
+        const assertion = jwt.sign(jwtAssertion(grant, {"sub": "invalid_subject"}), privatePem, { algorithm: "RS256" })
+
+        cy.request({
+            method: 'POST', 
+            url: tokenUrl,
+            form: true,
+            body: {
+                grant_type: 'urn:ietf:params:oauth:grant-type:jwt-bearer',
+                assertion: assertion,
+                scope: client.scope,
+            },
+            failOnStatusCode: false,
+        })
+        .its('status')
+        .then((status) => {
+            expect(status).to.be.equal(400)
+        })
+    })
+
+    it('[client auth optional] should return an Error (400) when given a JWT assertion with an invalid issuer', function () {
+        if (!canSkipClientAuth()) {
+            this.skip()
+        }
+        
+        const client = nc()
+        createClient(client)
+
+        const grant = gr(prng())
+        createGrant(grant)
+
+        const assertion = jwt.sign(jwtAssertion(grant, {"iss": "invalid_issuer"}), privatePem, { algorithm: "RS256" })
+
+        cy.request({
+            method: 'POST', 
+            url: tokenUrl,
+            form: true,
+            body: {
+                grant_type: 'urn:ietf:params:oauth:grant-type:jwt-bearer',
+                assertion: assertion,
+                scope: client.scope,
+            },
+            failOnStatusCode: false,
+        })
+        .its('status')
+        .then((status) => {
+            expect(status).to.be.equal(400)
+        })
+    })
+
+    it('[client auth optional] should return an Error (400) when given a JWT assertion with an invalid audience', function () {
+        if (!canSkipClientAuth()) {
+            this.skip()
+        }
+        
+        const client = nc()
+        createClient(client)
+
+        const grant = gr(prng())
+        createGrant(grant)
+
+        const assertion = jwt.sign(jwtAssertion(grant, {"aud": "invalid_audience"}), privatePem, { algorithm: "RS256" })
+
+        cy.request({
+            method: 'POST', 
+            url: tokenUrl,
+            form: true,
+            body: {
+                grant_type: 'urn:ietf:params:oauth:grant-type:jwt-bearer',
+                assertion: assertion,
+                scope: client.scope,
+            },
+            failOnStatusCode: false,
+        })
+        .its('status')
+        .then((status) => {
+            expect(status).to.be.equal(400)
+        })
+    })
+
+    it('[client auth optional] should return an Error (400) when given a JWT assertion with an expired date', function () {
+        if (!canSkipClientAuth()) {
+            this.skip()
+        }
+        
+        const client = nc()
+        createClient(client)
+
+        const grant = gr(prng())
+        createGrant(grant)
+
+        const assertion = jwt.sign(jwtAssertion(grant, {"exp": dayjs().utc().subtract(1, 'minute').set('millisecond', 0).unix()}), privatePem, { algorithm: "RS256" })
+
+        cy.request({
+            method: 'POST', 
+            url: tokenUrl,
+            form: true,
+            body: {
+                grant_type: 'urn:ietf:params:oauth:grant-type:jwt-bearer',
+                assertion: assertion,
+                scope: client.scope,
+            },
+            failOnStatusCode: false,
+        })
+        .its('status')
+        .then((status) => {
+            expect(status).to.be.equal(400)
+        })
+    })
+
+    it('[client auth optional] should return an Error (400) when given a JWT assertion with a nbf that is still not valid', function () {
+        if (!canSkipClientAuth()) {
+            this.skip()
+        }
+        
+        const client = nc()
+        createClient(client)
+
+        const grant = gr(prng())
+        createGrant(grant)
+
+        const assertion = jwt.sign(jwtAssertion(grant, {"nbf": dayjs().utc().add(1, 'minute').set('millisecond', 0).unix()}), privatePem, { algorithm: "RS256" })
+
+        cy.request({
+            method: 'POST', 
+            url: tokenUrl,
+            form: true,
+            body: {
+                grant_type: 'urn:ietf:params:oauth:grant-type:jwt-bearer',
+                assertion: assertion,
+                scope: client.scope,
+            },
+            failOnStatusCode: false,
+        })
+        .its('status')
+        .then((status) => {
+            expect(status).to.be.equal(400)
+        })
+    })
+
+    it('[client auth optional] should return an Access Token when given a JWT assertion with a nbf that is valid', function () {
+        if (!canSkipClientAuth()) {
+            this.skip()
+        }
+        
+        const client = nc()
+        createClient(client)
+
+        const grant = gr(prng())
+        createGrant(grant)
+
+        const assertion = jwt.sign(jwtAssertion(grant, {"nbf": dayjs().utc().subtract(1, 'minute').set('millisecond', 0).unix()}), privatePem, { algorithm: "RS256" })
+
+        cy.request({
+            method: 'POST', 
+            url: tokenUrl,
+            form: true,
+            body: {
+                grant_type: 'urn:ietf:params:oauth:grant-type:jwt-bearer',
+                assertion: assertion,
+                scope: client.scope,
+            },
+        })
+        .its('body')
+        .then((body) => {
+            const { access_token, expires_in, scope, token_type } = body
+
+            expect(access_token).to.not.be.empty
+            expect(expires_in).to.not.be.undefined
+            expect(scope).to.not.be.empty
+            expect(token_type).to.not.be.empty
+        })
+    })
+})

--- a/oauth2/trust/doc.go
+++ b/oauth2/trust/doc.go
@@ -132,16 +132,3 @@ type trustedJsonWebKey struct {
 	// example: 123e4567-e89b-12d3-a456-426655440000
 	KeyID string `json:"kid"`
 }
-
-// swagger:parameters flushInactiveJwtBearerGrants
-type swaggerFlushInactiveJWTBearerGrantsRequestParams struct {
-	// in: body
-	Body swaggerFlushInactiveJWTBearerGrantsParams
-}
-
-// swagger:model flushInactiveJwtBearerGrantsParams
-type swaggerFlushInactiveJWTBearerGrantsParams struct {
-	// The "notAfter" sets after which point grants should not be flushed. This is useful when you want to keep a history
-	// of recently added grants.
-	NotAfter time.Time `json:"notAfter"`
-}

--- a/oauth2/trust/handler.go
+++ b/oauth2/trust/handler.go
@@ -193,38 +193,3 @@ func (h *Handler) List(w http.ResponseWriter, r *http.Request, ps httprouter.Par
 
 	h.registry.Writer().Write(w, r, grants)
 }
-
-// swagger:route POST /grants/jwt-bearer/flush admin flushInactiveJwtBearerGrants
-//
-// Flush Expired jwt-bearer grants.
-//
-// This endpoint flushes expired jwt-bearer grants from the database. You can set a time after which no tokens will be
-// not be touched, in case you want to keep recent tokens for auditing. Refresh tokens can not be flushed as they are deleted
-// automatically when performing the refresh flow.
-//
-//     Consumes:
-//     - application/json
-//
-//     Schemes: http, https
-//
-//     Responses:
-//       204: emptyResponse
-//       500: genericError
-func (h *Handler) FlushHandler(w http.ResponseWriter, r *http.Request, _ httprouter.Params) {
-	var request flushInactiveGrantsRequest
-	if err := json.NewDecoder(r.Body).Decode(&request); err != nil {
-		h.registry.Writer().WriteError(w, r, err)
-		return
-	}
-
-	if request.NotAfter.IsZero() {
-		request.NotAfter = time.Now().UTC()
-	}
-
-	if err := h.registry.GrantManager().FlushInactiveGrants(r.Context(), request.NotAfter); err != nil {
-		h.registry.Writer().WriteError(w, r, err)
-		return
-	}
-
-	w.WriteHeader(http.StatusNoContent)
-}

--- a/oauth2/trust/request.go
+++ b/oauth2/trust/request.go
@@ -22,9 +22,3 @@ type createGrantRequest struct {
 	// ExpiresAt indicates, when grant will expire, so we will reject assertion from Issuer targeting Subject.
 	ExpiresAt time.Time `json:"expires_at"`
 }
-
-type flushInactiveGrantsRequest struct {
-	// NotAfter sets after which point grants should not be flushed. This is useful when you want to keep a history
-	// of recently added grants.
-	NotAfter time.Time `json:"notAfter"`
-}

--- a/oauth2/trust/validator_test.go
+++ b/oauth2/trust/validator_test.go
@@ -1,0 +1,93 @@
+package trust
+
+import (
+	"testing"
+	"time"
+
+	"gopkg.in/square/go-jose.v2"
+)
+
+func TestEmptyIssuerIsInvalid(t *testing.T) {
+	v := GrantValidator{}
+
+	r := createGrantRequest{
+		Issuer:    "",
+		Subject:   "valid-subject",
+		ExpiresAt: time.Now().Add(time.Hour * 10),
+		PublicKeyJWK: jose.JSONWebKey{
+			KeyID: "valid-key-id",
+		},
+	}
+
+	if err := v.Validate(r); err == nil {
+		t.Error("an empty issuer should not be valid")
+	}
+}
+
+func TestEmptySubjectIsInvalid(t *testing.T) {
+	v := GrantValidator{}
+
+	r := createGrantRequest{
+		Issuer:    "valid-issuer",
+		Subject:   "",
+		ExpiresAt: time.Now().Add(time.Hour * 10),
+		PublicKeyJWK: jose.JSONWebKey{
+			KeyID: "valid-key-id",
+		},
+	}
+
+	if err := v.Validate(r); err == nil {
+		t.Error("an empty subject should not be valid")
+	}
+}
+
+func TestEmptyExpiresAtIsInvalid(t *testing.T) {
+	v := GrantValidator{}
+
+	r := createGrantRequest{
+		Issuer:    "valid-issuer",
+		Subject:   "valid-subject",
+		ExpiresAt: time.Time{},
+		PublicKeyJWK: jose.JSONWebKey{
+			KeyID: "valid-key-id",
+		},
+	}
+
+	if err := v.Validate(r); err == nil {
+		t.Error("an empty expiration should not be valid")
+	}
+}
+
+func TestEmptyPublicKeyIdIsInvalid(t *testing.T) {
+	v := GrantValidator{}
+
+	r := createGrantRequest{
+		Issuer:    "valid-issuer",
+		Subject:   "valid-subject",
+		ExpiresAt: time.Now().Add(time.Hour * 10),
+		PublicKeyJWK: jose.JSONWebKey{
+			KeyID: "",
+		},
+	}
+
+	if err := v.Validate(r); err == nil {
+		t.Error("an empty public key id should not be valid")
+	}
+}
+
+func TestIsValid(t *testing.T) {
+	v := GrantValidator{}
+
+	r := createGrantRequest{
+		Issuer:    "valid-issuer",
+		Subject:   "valid-subject",
+		ExpiresAt: time.Now().Add(time.Hour * 10),
+		PublicKeyJWK: jose.JSONWebKey{
+			KeyID: "valid-key-id",
+		},
+	}
+
+	if err := v.Validate(r); err != nil {
+		t.Error("A request with an issuer, a subject, an expiration and a public key should be valid")
+	}
+}

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
   "devDependencies": {
     "cypress": "^7.7.0",
     "dayjs": "^1.10.6",
+    "jsonwebtoken": "^8.5.1",
     "ory-prettier-styles": "1.1.1",
     "prettier": "2.1.2",
     "standard": "^12.0.1",

--- a/persistence/sql/migrations/20201211145331000000_grant_jwk_bearer.cockroach.down.sql
+++ b/persistence/sql/migrations/20201211145331000000_grant_jwk_bearer.cockroach.down.sql
@@ -1,1 +1,3 @@
+DROP INDEX hydra_oauth2_trusted_jwt_bearer_issuer_expires_at_idx;
+
 DROP TABLE IF EXISTS hydra_oauth2_trusted_jwt_bearer_issuer;

--- a/persistence/sql/migrations/20201211145331000000_grant_jwk_bearer.cockroach.up.sql
+++ b/persistence/sql/migrations/20201211145331000000_grant_jwk_bearer.cockroach.up.sql
@@ -11,3 +11,5 @@ CREATE TABLE IF NOT EXISTS hydra_oauth2_trusted_jwt_bearer_issuer
     UNIQUE (issuer, subject, key_id),
     FOREIGN KEY (key_set, key_id) REFERENCES hydra_jwk (sid, kid) ON DELETE CASCADE
 );
+
+CREATE INDEX hydra_oauth2_trusted_jwt_bearer_issuer_expires_at_idx ON hydra_oauth2_trusted_jwt_bearer_issuer (expires_at);

--- a/persistence/sql/migrations/20201211145331000000_grant_jwk_bearer.mysql.down.sql
+++ b/persistence/sql/migrations/20201211145331000000_grant_jwk_bearer.mysql.down.sql
@@ -1,1 +1,3 @@
+DROP INDEX hydra_oauth2_trusted_jwt_bearer_issuer_expires_at_idx;
+
 DROP TABLE IF EXISTS hydra_oauth2_trusted_jwt_bearer_issuer;

--- a/persistence/sql/migrations/20201211145331000000_grant_jwk_bearer.mysql.up.sql
+++ b/persistence/sql/migrations/20201211145331000000_grant_jwk_bearer.mysql.up.sql
@@ -11,3 +11,5 @@ CREATE TABLE IF NOT EXISTS hydra_oauth2_trusted_jwt_bearer_issuer
     UNIQUE (issuer, subject, key_id),
     FOREIGN KEY (key_set, key_id) REFERENCES hydra_jwk (sid, kid) ON DELETE CASCADE
 );
+
+CREATE INDEX hydra_oauth2_trusted_jwt_bearer_issuer_expires_at_idx ON hydra_oauth2_trusted_jwt_bearer_issuer (expires_at);

--- a/persistence/sql/migrations/20201211145331000000_grant_jwk_bearer.postgres.down.sql
+++ b/persistence/sql/migrations/20201211145331000000_grant_jwk_bearer.postgres.down.sql
@@ -1,1 +1,3 @@
+DROP INDEX hydra_oauth2_trusted_jwt_bearer_issuer_expires_at_idx;
+
 DROP TABLE IF EXISTS hydra_oauth2_trusted_jwt_bearer_issuer;

--- a/persistence/sql/migrations/20201211145331000000_grant_jwk_bearer.postgres.up.sql
+++ b/persistence/sql/migrations/20201211145331000000_grant_jwk_bearer.postgres.up.sql
@@ -11,3 +11,5 @@ CREATE TABLE IF NOT EXISTS hydra_oauth2_trusted_jwt_bearer_issuer
     UNIQUE (issuer, subject, key_id),
     FOREIGN KEY (key_set, key_id) REFERENCES hydra_jwk (sid, kid) ON DELETE CASCADE
 );
+
+CREATE INDEX hydra_oauth2_trusted_jwt_bearer_issuer_expires_at_idx ON hydra_oauth2_trusted_jwt_bearer_issuer (expires_at);

--- a/persistence/sql/migrations/20201211145331000000_grant_jwk_bearer.sqlite.down.sql
+++ b/persistence/sql/migrations/20201211145331000000_grant_jwk_bearer.sqlite.down.sql
@@ -1,1 +1,3 @@
+DROP INDEX hydra_oauth2_trusted_jwt_bearer_issuer_expires_at_idx;
+
 DROP TABLE IF EXISTS hydra_oauth2_trusted_jwt_bearer_issuer;

--- a/persistence/sql/migrations/20201211145331000000_grant_jwk_bearer.sqlite.up.sql
+++ b/persistence/sql/migrations/20201211145331000000_grant_jwk_bearer.sqlite.up.sql
@@ -11,3 +11,5 @@ CREATE TABLE IF NOT EXISTS hydra_oauth2_trusted_jwt_bearer_issuer
     UNIQUE (issuer, subject, key_id),
     FOREIGN KEY (key_set, key_id) REFERENCES hydra_jwk (sid, kid) ON DELETE CASCADE
 );
+
+CREATE INDEX hydra_oauth2_trusted_jwt_bearer_issuer_expires_at_idx ON hydra_oauth2_trusted_jwt_bearer_issuer (expires_at);

--- a/persistence/sql/persister_grant_jwk.go
+++ b/persistence/sql/persister_grant_jwk.go
@@ -45,12 +45,12 @@ func (p *Persister) GetConcreteGrant(ctx context.Context, id string) (trust.Gran
 }
 
 func (p *Persister) DeleteGrant(ctx context.Context, id string) error {
-	grant, err := p.GetConcreteGrant(ctx, id)
-	if err != nil {
-		return err
-	}
-
 	return p.transaction(ctx, func(ctx context.Context, c *pop.Connection) error {
+		grant, err := p.GetConcreteGrant(ctx, id)
+		if err != nil {
+			return sqlcon.HandleError(err)
+		}
+
 		if err := p.Connection(ctx).Destroy(&trust.SQLData{ID: grant.ID}); err != nil {
 			return sqlcon.HandleError(err)
 		}

--- a/persistence/sql/persister_grant_jwk.go
+++ b/persistence/sql/persister_grant_jwk.go
@@ -187,9 +187,12 @@ func (p *Persister) jwtGrantFromSQlData(data trust.SQLData) trust.Grant {
 }
 
 func (p *Persister) FlushInactiveGrants(ctx context.Context, notAfter time.Time) error {
+	deleteUntil := time.Now().UTC()
+	if deleteUntil.After(notAfter) {
+		deleteUntil = notAfter
+	}
 	return sqlcon.HandleError(p.Connection(ctx).RawQuery(
-		fmt.Sprintf("DELETE FROM %s WHERE expires_at < ? AND expires_at < ?", trust.SQLData{}.TableName()),
-		time.Now().UTC(),
-		notAfter,
+		fmt.Sprintf("DELETE FROM %s WHERE expires_at < ?", trust.SQLData{}.TableName()),
+		deleteUntil,
 	).Exec())
 }


### PR DESCRIPTION
I'm opening this PR to keep track of the progress I make.

I'll also try to add a comment on each of the changes requested by @aeneasr in the original PR (https://github.com/ory/hydra/pull/2384). That way everyone will be aware of what this PR includes.

- [x] Added end-to-end tests (https://github.com/ory/hydra/pull/2384#pullrequestreview-705209004)
- [x] Added tests for the `GrantValidator.Validate` method (https://github.com/ory/hydra/pull/2384#discussion_r668824362)
- [x] Use pipe instead of space to store jwt grant scopes in the database (https://github.com/ory/hydra/pull/2384#discussion_r668840953)
- [x] Add database index to the `expires_at` column (https://github.com/ory/hydra/pull/2384#discussion_r668841475)
- [x] Get the smallest time to save one DB filter when flushing grants (https://github.com/ory/hydra/pull/2384#discussion_r668846123)
- [x] Make `DeleteGrant` in a single transaction (https://github.com/ory/hydra/pull/2384#discussion_r668848686)
- [x] Use a single transaction in the `CreateGrant` function (https://github.com/ory/hydra/pull/2384#discussion_r668851526)
- [x] Remove flush expired grants endpoint and add it to the `janitor` CLI (https://github.com/ory/hydra/pull/2384#discussion_r668779091)

This is the simplest way to work on this I can think of.