### PR TITLE
feat: remove redundant end-to-end tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -113,16 +113,12 @@ jobs:
 
       - run: ./test/e2e/circle-ci.bash memory
       - run: ./test/e2e/circle-ci.bash memory --jwt
-      - run: ./test/e2e/circle-ci.bash memory --grant_jwt_jti_optional --grant_jwt_iat_optional
       - run: ./test/e2e/circle-ci.bash cockroach
       - run: ./test/e2e/circle-ci.bash cockroach --jwt
-      - run: ./test/e2e/circle-ci.bash cockroach --grant_jwt_jti_optional --grant_jwt_iat_optional
       - run: ./test/e2e/circle-ci.bash mysql
       - run: ./test/e2e/circle-ci.bash mysql --jwt
-      - run: ./test/e2e/circle-ci.bash mysql --grant_jwt_jti_optional --grant_jwt_iat_optional
       - run: ./test/e2e/circle-ci.bash postgres
       - run: ./test/e2e/circle-ci.bash postgres --jwt
-      - run: ./test/e2e/circle-ci.bash postgres --grant_jwt_jti_optional --grant_jwt_iat_optional
 
 
 workflows:

--- a/Makefile
+++ b/Makefile
@@ -86,7 +86,6 @@ e2e: node_modules test-resetdb
 		for db in memory postgres mysql cockroach; do \
 			./test/e2e/circle-ci.bash "$${db}"; \
 			./test/e2e/circle-ci.bash "$${db}" --jwt; \
-			./test/e2e/circle-ci.bash "$${db}" --grant_jwt_jti_optional --grant_jwt_iat_optional; \
 		done
 
 # Runs tests in short mode, without database adapters

--- a/cypress.json
+++ b/cypress.json
@@ -6,9 +6,7 @@
     "client_url": "http://127.0.0.1:5003",
     "public_port": "5000",
     "client_port": "5003",
-    "jwt_enabled": false,
-    "grant_jwt_jti_optional": false,
-    "grant_jwt_iat_optional": false
+    "jwt_enabled": false
   },
   "chromeWebSecurity": false,
   "retries": {

--- a/cypress/integration/oauth2/grant_jwtbearer.js
+++ b/cypress/integration/oauth2/grant_jwtbearer.js
@@ -16,9 +16,6 @@ describe('The OAuth 2.0 JWT Bearer (RFC 7523) Grant', function () {
 
     const tokenUrl = `${Cypress.env('public_url')}/oauth2/token`
 
-    const jtiOptional = () => Cypress.env('grant_jwt_jti_optional') === 'true' || Boolean(Cypress.env('grant_jwt_jti_optional'))
-    const iatOptional = () => Cypress.env('grant_jwt_iat_optional') === 'true' || Boolean(Cypress.env('grant_jwt_iat_optional'))
-
     const nc = () => ({
         client_id: prng(),
         client_secret: prng(),
@@ -108,11 +105,7 @@ describe('The OAuth 2.0 JWT Bearer (RFC 7523) Grant', function () {
         })
     })
 
-    it('[jti required] should return an Error (400) when given client credentials and a JWT assertion without a jti', function () {
-        if (jtiOptional()) {
-            this.skip()
-        }
-
+    it('should return an Error (400) when given client credentials and a JWT assertion without a jti', function () {
         const client = nc()
         createClient(client)
 
@@ -198,11 +191,7 @@ describe('The OAuth 2.0 JWT Bearer (RFC 7523) Grant', function () {
         })
     })
 
-    it('[iat required] should return an Error (400) when given client credentials and a JWT assertion without an iat', function () {
-        if (iatOptional()) {
-            this.skip()
-        }
-
+    it('should return an Error (400) when given client credentials and a JWT assertion without an iat', function () {
         const client = nc()
         createClient(client)
 

--- a/test/e2e/circle-ci.bash
+++ b/test/e2e/circle-ci.bash
@@ -82,17 +82,9 @@ case $i in
         export OIDC_SUBJECT_IDENTIFIERS_SUPPORTED_TYPES=public
         export CYPRESS_jwt_enabled=true
     ;;
-    --grant_jwt_jti_optional)
-        export OAUTH2_GRANT_JWT_JTI_OPTIONAL=true
-        export CYPRESS_grant_jwt_jti_optional=true
-    ;;
-    --grant_jwt_iat_optional)
-        export OAUTH2_GRANT_JWT_IAT_OPTIONAL=true
-        export CYPRESS_grant_jwt_iat_optional=true
-    ;;
     *)
         echo $"Invalid param $i"
-        echo $"Usage: $0 [memory|postgres|mysql|cockroach] [--watch][--jwt][--grant_jwt_jti_optional][--grant_jwt_iat_optional]"
+        echo $"Usage: $0 [memory|postgres|mysql|cockroach] [--watch][--jwt]"
         exit 1
     ;;
 esac


### PR DESCRIPTION
End-to-end tests are taking too long to run and the circle-ci pipeline is failing with a time out. We could probably increase the timeout on circle-ci, but I think some tests we are running are redundant.

This change merges the redundant cases together.


More info: https://github.com/ory/hydra/pull/2384#issuecomment-983503729